### PR TITLE
rebuild 0.8.0 w/ correct metadata version

### DIFF
--- a/recipe/0001-fix-version.patch
+++ b/recipe/0001-fix-version.patch
@@ -1,0 +1,10 @@
+--- pyproject.toml	2022-11-04 13:20:47.000000000 +0100
++++ pyproject.toml	2024-01-08 13:27:48.772803360 +0100
+@@ -1,6 +1,6 @@
+ [project]
+ name = "pydeck"
+-version = "0.8.0b4"
++version = "0.8.0"
+ requires-python = ">=3.7"
+ 
+ [build-system]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-fix-version.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<37]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 07edde833f7cfcef6749124351195aa7dcd24663d4909fd7898dbd0b6fbc01ec
+  patches:
+    - 0001-fix-version.patch
 
 build:
   number: 0
@@ -15,6 +17,9 @@ build:
   skip: true  # [py<37]
 
 requirements:
+  build:
+    - patch  # [win]
+    - m2-patch  # [not win]
   host:
     - python 
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,8 @@ build:
 
 requirements:
   build:
-    - patch  # [win]
-    - m2-patch  # [not win]
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - python 
     - pip


### PR DESCRIPTION
pydeck 0.8.0

**Destination channel:** defaults

### Links

- [PKG-3743]
- [Upstream repository](https://github.com/visgl/deck.gl/tree/master/bindings/pydeck)
- [Upstream changelog/diff](https://github.com/visgl/deck.gl/blob/master/bindings/pydeck/docs/CHANGELOG.rst)

### Explanation of changes:

- upstream had wrong version which results in `pip check` of dependent packages to detect e beta `0.8.0b4`, which does not fulfill requirement `>=0.8.0`, e.g. [streamlit-plotly-events](https://github.com/AnacondaRecipes/streamlit-plotly-events-feedstock/pull/2) will fail because of this.


[PKG-3743]: https://anaconda.atlassian.net/browse/PKG-3743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ